### PR TITLE
Fix should not mutate original sizes

### DIFF
--- a/src/bricks.js
+++ b/src/bricks.js
@@ -19,7 +19,7 @@ export default (options = {}) => {
 
   const container = document.querySelector(options.container)
   const packed    = options.packed.indexOf('data-') === 0 ? options.packed : `data-${ options.packed }`
-  const sizes     = options.sizes.reverse()
+  const sizes     = options.sizes.slice().reverse()
 
   const selectors = {
     all: `${ options.container } > *`,


### PR DESCRIPTION
Bricks should not mutate the original sizes.

As I am using bricks with react, and I set `sizes` as props.
every time I switch pages, I find that the layout changes.
After investigating, I find that when initializing bricks instance, my `sizes` props changed.

So, this pr is trying to solve the problem above.
