### PR TITLE
Hotfix: position

### DIFF
--- a/src/bricks.js
+++ b/src/bricks.js
@@ -123,13 +123,12 @@ const bricks = (options = {}) => {
     nodes.forEach((element, index) => {
       columnTarget = columnHeights.indexOf(Math.min.apply(Math, columnHeights))
 
-      element.style.position = 'absolute'
-
       nodeTop = `${columnHeights[columnTarget]}px`
       nodeLeft = `${(columnTarget * nodesWidths[index]) + (columnTarget * sizeDetail.gutter)}px`
 
       // support positioned elements (default) or transformed elements
       if (position) {
+        element.style.position = 'absolute'
         element.style.top = nodeTop
         element.style.left = nodeLeft
       } else {


### PR DESCRIPTION
Only add `position: absolute` if position option is `true`.
`position: absolute` in not needed when transforms are used.