### PR TITLE
fix(dimensions): use getBoundingClientRect() instead of clientHeight

### DIFF
--- a/src/bricks.js
+++ b/src/bricks.js
@@ -116,7 +116,7 @@ const bricks = (options = {}) => {
     }
 
     nodesWidths = nodes.map(element => element.clientWidth)
-    nodesHeights = nodes.map(element => element.clientHeight)
+    nodesHeights = nodes.map(element => Math.ceil(element.getBoundingClientRect().height))
   }
 
   function setNodesStyles () {


### PR DESCRIPTION
This PR solves a small layout bug when instantiating the bricks.

If the bricks have a dom height with decimal value (e.g. `512.35`),  `element.clientHeight` returns a rounded value for the element height and does not render the layout correctly when looking for the target column (columnTarget).

So if we have 5 bricks all with an height of `512.35px`, and a lyout with 4 columns, the `columnHeights` might look like `[512, 513, 512, 513, 512]` and the 5th element would be aligned at the 4th column instead of the 1st one.